### PR TITLE
chore(deps): add 3-day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     schedule:
       interval: daily
     versioning-strategy: increase
+    cooldown:
+      default-days: 3
     groups:
       tanstack:
         patterns:


### PR DESCRIPTION
Configure Dependabot to enforce a 3-day cooldown between updates to reduce noise and improve batching of dependency PRs.